### PR TITLE
Itinerry chat improvements and metadata match with llm json response

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -297,17 +297,27 @@ class MessagesController < ApplicationController
         date: Date.parse(day_data.fetch("date"))
       )
 
+      trip_day.update!(
+        name: day_data.fetch("name")
+      )
+
       day_data.fetch("activities").each do |activity_data|
         start_date = Time.zone.parse(
           "#{trip_day.date} #{activity_data.fetch("start_time")}"
         )
 
+        category = activity_data.fetch("category")
+
+        unless Activity::CATEGORIES.include?(category)
+          category = "sightseeing"
+        end
+
         trip_day.activities.create!(
           name: activity_data.fetch("name"),
-          category: activity_data.fetch("category"),
+          category: category,
           address: activity_data.fetch("address"),
           description: activity_data.fetch("description"),
-          notes: activity_data["notes"],
+          notes: activity_data.fetch("notes"),
           start_date: start_date,
           end_date: start_date + activity_data.fetch("duration_minutes").minutes
         )

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -73,9 +73,12 @@ class TripsController < ApplicationController
   def show
     @trip = Trip.find(params[:id])
     authorize @trip
+
     @trip_days = @trip.trip_days.order(date: :asc)
-    @trip_day = @trip_days[params[:day].to_i - 1]
-    # @activity = Activity.find(params[:id])
+
+    day_number = (params[:day] || 1).to_i
+    @trip_day = @trip_days[day_number - 1]
+
     @activities = @trip_day.activities.order(start_date: :asc)
   end
 

--- a/app/javascript/controllers/chat_controller.js
+++ b/app/javascript/controllers/chat_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.messages = this.element.querySelector(".chat-messages")
+
+    this.scrollToBottom()
+
+    this.observer = new MutationObserver(() => {
+      this.scrollToBottom()
+    })
+
+    this.observer.observe(this.messages, {
+      childList: true,
+      subtree: true
+    })
+  }
+
+  disconnect() {
+    if (this.observer) {
+      this.observer.disconnect()
+    }
+  }
+
+  scrollToBottom() {
+    this.messages.scrollTo({
+      top: this.messages.scrollHeight,
+      behavior: "smooth"
+    })
+  }
+  preventBlank(event) {
+    const input = event.target.querySelector(".message-input")
+
+    if (input.value.trim() === "") {
+      event.preventDefault()
+      input.focus()
+    }
+  }
+}

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,7 +1,7 @@
 class Activity < ApplicationRecord
   belongs_to :trip_day
 
-  CATEGORIES = %w[accommodation beach entertainment food hiking leisure sightseeing transportation].freeze
+  CATEGORIES = %w[accommodation cultural entertainment food hiking leisure sightseeing transportation].freeze
 
   geocoded_by :address
   after_validation :geocode, if: :will_save_change_to_address?

--- a/app/prompts/messages/itinerary.txt
+++ b/app/prompts/messages/itinerary.txt
@@ -4,6 +4,7 @@ Create a realistic day-by-day itinerary using ALL known trip information.
 
 Respect:
 - exact trip dates
+- destination
 - group size
 - budget
 - vibe
@@ -33,20 +34,19 @@ Do not recommend accommodation unless requested.
 Do not include a separate budget breakdown.
 
 NEVER repeat the same attraction, landmark, neighborhood, museum,
-garden, beach, or venue on different days.
+garden, cultural venue, or other venue on different days.
 
 Before choosing an activity, check all previous days and select
 a different place if it has already been used.
 
 Every day, including DAY 1 and the FINAL DAY,
-must contain at least one properly formatted activity block.
+must contain at least one real activity.
 
 The FINAL DAY must NEVER contain free text such as
 "flexible morning", "departure preparations", or similar.
 
 If the first or last day should be lighter,
-use only 1 or 2 real activities,
-but still use the exact activity format.
+use only 1 or 2 real activities.
 
 Do not output vague or free-form suggestions such as:
 "flexible morning options",
@@ -58,9 +58,8 @@ or similar wording.
 The itinerary will later be displayed as activity cards.
 
 For each day include:
-- day number
-- short day theme
 - exact date
+- short day theme
 - approximately 3 to 5 activities when realistic
 
 For each activity include:
@@ -68,42 +67,71 @@ For each activity include:
 - activity name
 - category
 - duration
-- useful address or area
+- useful address
 - one short description
 - one short note only when useful
 
-End each day with:
-- number of stops
-- approximate active time
-- main transportation method
+Category MUST be exactly one of:
+- accommodation
+- cultural
+- entertainment
+- food
+- hiking
+- leisure
+- sightseeing
+- transportation
 
-Use EXACTLY this format:
+Never use any other category.
 
-DAY 1 — Short theme
-Date: exact trip date
+Use:
+- cultural for cultural experiences, traditions, performances, workshops, festivals, and similar cultural activities
+- sightseeing for museums, landmarks, neighborhoods, gardens, monuments, and general attractions
+- food for restaurants, cafes, food markets, and food experiences
+- leisure for spas, beaches, hot springs, relaxing parks, and similar relaxed activities
+- hiking for hikes, trails, and trekking
+- transportation for arrivals, departures, transfers, trains, buses, and similar transportation activities
+- entertainment for shows, nightlife, amusement, ziplining, and similar activities
+- accommodation for hotels and lodging
 
-10:00 — Activity name
-Category: culture
-Duration: 1.5 hr
-Address: useful location or area
-Description: One short sentence.
-Notes: Short useful note.
+Addresses must be specific and useful for geocoding.
+Use the trip destination as geographic context for every address.
+Include city and country when useful to avoid ambiguity.
 
-13:00 — Activity name
-Category: food
-Duration: 1 hr
-Address: useful location or area
-Description: One short sentence.
+TIME RULES:
+- start_time must use 24-hour HH:MM format
+- duration_minutes must be a positive integer
+- do not output end_time
+- Rails will calculate the end time from start_time and duration_minutes
 
-Day summary: 2 stops · ~2.5 hr · walking
+OUTPUT RULES:
+- Return ONLY valid JSON.
+- Do not use Markdown.
+- Do not use code fences.
+- Do not output any text before or after the JSON.
+- Do not output latitude or longitude.
+- Do not output image URLs.
+- Do not output end times.
+- Every required key must be present.
+- notes must be a string and may be empty when there is no useful note.
 
-Keep it TL;DR:
-- no paragraphs
-- no filler
-- descriptions are one short sentence
-- notes are optional and very short
-- categories should normally be one word
-- keep each field on its own line
-- put a blank line between activities
-- put two blank lines between days
-- do not use Markdown headings, bold text, tables, or bullet symbols
+Use EXACTLY this JSON structure:
+
+{
+  "days": [
+    {
+      "date": "YYYY-MM-DD",
+      "name": "Short day theme",
+      "activities": [
+        {
+          "start_time": "09:30",
+          "duration_minutes": 90,
+          "name": "Specific activity name",
+          "category": "sightseeing",
+          "address": "Specific useful address, city, country",
+          "description": "One short sentence.",
+          "notes": ""
+        }
+      ]
+    }
+  ]
+}

--- a/app/views/chats/show.html.erb
+++ b/app/views/chats/show.html.erb
@@ -1,4 +1,4 @@
-<div class="chat-page">
+<div class="chat-page" data-controller="chat">
 
   <div class="chat-header">
     <div>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -1,5 +1,8 @@
 <%= simple_form_for [trip, chat, message],
-                    html: { class: "message-form" } do |f| %>
+                    html: {
+                      class: "message-form",
+                      data: { action: "submit->chat#preventBlank" }
+                    } do |f| %>
 
   <div class="message-input-wrapper">
     <%= f.input :content,
@@ -8,7 +11,8 @@
                 wrapper: false,
                 input_html: {
                   class: "message-input",
-                  autocomplete: "off"
+                  autocomplete: "off",
+                  autofocus: true
                 },
                 placeholder: "Tell itinera..." %>
 

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -4,8 +4,12 @@
 
 <div class="trip-header">
   <div>
-    <h1><%= @trip.name %></h1>
-    <p>20-27 Aug 2026 • <%= @trip_days.count %> days</p>
+    <h1><%= @trip.name.presence || @trip.destination %></h1>
+    <p>
+      <%= @trip_days.first.date.strftime("%d %b") %> -
+      <%= @trip_days.last.date.strftime("%d %b %Y") %>
+      • <%= @trip_days.count %> days
+  </p>
   </div>
 
   <%= render "trip_actions", trip: @trip %>


### PR DESCRIPTION
- Changed itinerary generation to structured JSON
- Persist LLM-generated day names into TripDay.name
- Persist generated activities into the database
- Calculate start_date / end_date from start_time + duration_minutes
- Validate generated activity categories; invalid ones fall back to sightseeing
- Fixed trip page to open on Day 1 by default
- Replaced hardcoded trip dates with actual trip dates
- Trip title falls back to destination
- Generated addresses automatically geocode to lat/lng
- Generated activities appear on the Mapbox map
- Added chat autofocus
- Added chat auto-scroll
- Prevented blank/whitespace messages
- Removed beach category
- Added cultural category
- Updated itinerary prompt to use the new categories
- Final categories: accommodation, cultural, entertainment, food, hiking, leisure, sightseeing, transportation
- Remaining: final QA → Demo Day curated content/images → UI polish