### PR TITLE
Improved itinerary generation

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -32,7 +32,6 @@ class MessagesController < ApplicationController
 
   CONVERSATION_PROMPT = PromptTemplate.read("messages/conversation")
   SUMMARY_PROMPT = PromptTemplate.read("messages/summary")
-  ITINERARY_PROMPT = PromptTemplate.read("messages/itinerary")
   MODIFY_PROMPT = PromptTemplate.read("messages/modify_itinerary")
 
   def create
@@ -56,11 +55,6 @@ class MessagesController < ApplicationController
       broadcast_append(@assistant_message)
 
       continue_conversation
-
-      if @redirect_to_trip
-        redirect_to trip_path(@trip), status: :see_other
-        return
-      end
 
       respond_to do |format|
         format.turbo_stream
@@ -312,73 +306,14 @@ class MessagesController < ApplicationController
   end
 
   def generate_itinerary
-    ruby_llm_chat = RubyLLM.chat
+    GenerateItineraryJob.perform_later(
+      trip: @trip,
+      chat: @chat,
+      assistant_message: @assistant_message,
+      trip_context: trip_context,
+      questionnaire_context: questionnaire_context
+    )
 
-    Rails.logger.info "=" * 80
-    Rails.logger.info "TRIP CONTEXT SENT TO LLM"
-    Rails.logger.info trip_context
-    Rails.logger.info "=" * 80
-
-    response = ruby_llm_chat
-               .with_instructions(
-                 [
-                   ITINERARY_PROMPT,
-                   trip_context,
-                   questionnaire_context
-                 ].join("\n\n")
-               )
-               .ask("Generate the detailed itinerary using the trip information provided.")
-
-    print_generated_itinerary(response.content)
-    save_generated_itinerary(response.content)
-
-    @assistant_message.destroy!
-    @redirect_to_trip = true
-  end
-
-  def print_generated_itinerary(content)
-    Rails.logger.info "\n\n"
-    Rails.logger.info "=" * 80
-    Rails.logger.info "GENERATED ITINERARY"
-    Rails.logger.info "=" * 80
-    Rails.logger.info content
-    Rails.logger.info "=" * 80
-    Rails.logger.info "\n\n"
-  end
-
-  def save_generated_itinerary(content)
-    data = JSON.parse(content)
-
-    data.fetch("days").each do |day_data|
-      trip_day = @trip.trip_days.find_by!(
-        date: Date.parse(day_data.fetch("date"))
-      )
-
-      trip_day.update!(
-        name: day_data.fetch("name")
-      )
-
-      day_data.fetch("activities").each do |activity_data|
-        start_date = Time.zone.parse(
-          "#{trip_day.date} #{activity_data.fetch('start_time')}"
-        )
-
-        category = activity_data.fetch("category")
-
-        unless Activity::CATEGORIES.include?(category)
-          category = "sightseeing"
-        end
-
-        trip_day.activities.create!(
-          name: activity_data.fetch("name"),
-          category: category,
-          address: activity_data.fetch("address"),
-          description: activity_data.fetch("description"),
-          notes: activity_data.fetch("notes"),
-          start_date: start_date,
-          end_date: start_date + activity_data.fetch("duration_minutes").minutes
-        )
-      end
-    end
+    set_assistant_message("GENERATING_ITINERARY")
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,7 +1,11 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import "@hotwired/turbo-rails"
+import { Turbo } from "@hotwired/turbo-rails"
 import * as ActiveStorage from "@rails/activestorage"
 import "controllers"
+
+Turbo.StreamActions.redirect = function () {
+  Turbo.visit(this.getAttribute("url"))
+}
 
 ActiveStorage.start()
 import "@popperjs/core"

--- a/app/javascript/controllers/generating_message_controller.js
+++ b/app/javascript/controllers/generating_message_controller.js
@@ -1,0 +1,36 @@
+import { Controller } from "@hotwired/stimulus"
+
+const MESSAGES = [
+  "Queuing for the bus...",
+  "Bribing the local pigeons for insider tips...",
+  "Arguing with a map about which way is north...",
+  "Making sure the museums haven't wandered off...",
+  "Finding the nearest free toilet..."
+]
+
+const MIN_DELAY_MS = 2000
+const MAX_DELAY_MS = 4000
+
+export default class extends Controller {
+  static targets = ["text"]
+
+  connect() {
+    this.index = 0
+    this.textTarget.textContent = MESSAGES[this.index]
+    this.scheduleNext()
+  }
+
+  disconnect() {
+    clearTimeout(this.timeout)
+  }
+
+  scheduleNext() {
+    const delay = MIN_DELAY_MS + Math.random() * (MAX_DELAY_MS - MIN_DELAY_MS)
+
+    this.timeout = setTimeout(() => {
+      this.index = (this.index + 1) % MESSAGES.length
+      this.textTarget.textContent = MESSAGES[this.index]
+      this.scheduleNext()
+    }, delay)
+  }
+}

--- a/app/jobs/generate_itinerary_job.rb
+++ b/app/jobs/generate_itinerary_job.rb
@@ -1,0 +1,87 @@
+class GenerateItineraryJob < ApplicationJob
+  queue_as :default
+
+  ITINERARY_PROMPT = PromptTemplate.read("messages/itinerary")
+
+  def perform(trip:, chat:, assistant_message:, trip_context:, questionnaire_context:)
+    response = RubyLLM.chat
+                      .with_instructions(
+                        [
+                          ITINERARY_PROMPT,
+                          trip_context,
+                          questionnaire_context
+                        ].join("\n\n")
+                      )
+                      .ask("Generate the detailed itinerary using the trip information provided.")
+
+    save_generated_itinerary(trip, response.content)
+
+    assistant_message.update!(content: "Your itinerary is ready! Taking you there now...")
+    broadcast_replace(chat, assistant_message)
+    broadcast_redirect(chat, trip)
+  rescue StandardError => e
+    Rails.logger.error("GenerateItineraryJob failed for trip #{trip.id}: #{e.class} #{e.message}")
+
+    assistant_message.update!(
+      content: "Something went wrong generating your itinerary. Please try again."
+    )
+    broadcast_replace(chat, assistant_message)
+  end
+
+  private
+
+  def save_generated_itinerary(trip, content)
+    data = JSON.parse(content)
+
+    data.fetch("days").each do |day_data|
+      trip_day = trip.trip_days.find_by!(
+        date: Date.parse(day_data.fetch("date"))
+      )
+
+      trip_day.update!(
+        name: day_data.fetch("name")
+      )
+
+      day_data.fetch("activities").each do |activity_data|
+        start_date = Time.zone.parse(
+          "#{trip_day.date} #{activity_data.fetch('start_time')}"
+        )
+
+        category = activity_data.fetch("category")
+
+        category = "sightseeing" unless Activity::CATEGORIES.include?(category)
+
+        trip_day.activities.create!(
+          name: activity_data.fetch("name"),
+          category: category,
+          address: activity_data.fetch("address"),
+          description: activity_data.fetch("description"),
+          notes: activity_data.fetch("notes"),
+          start_date: start_date,
+          end_date: start_date + activity_data.fetch("duration_minutes").minutes
+        )
+      end
+    end
+  end
+
+  def broadcast_replace(chat, message)
+    Turbo::StreamsChannel.broadcast_replace_to(
+      chat,
+      target: ActionView::RecordIdentifier.dom_id(message),
+      partial: "messages/message",
+      locals: {
+        message: message
+      }
+    )
+  end
+
+  def broadcast_redirect(chat, trip)
+    Turbo::StreamsChannel.broadcast_action_to(
+      chat,
+      action: :redirect,
+      attributes: {
+        url: Rails.application.routes.url_helpers.trip_path(trip)
+      }
+    )
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -2,9 +2,12 @@ class Activity < ApplicationRecord
   belongs_to :trip_day
 
   CATEGORIES = %w[accommodation cultural entertainment food hiking leisure sightseeing transportation].freeze
+  DEFAULT_IMAGE_URL = "activity-placeholder.svg"
 
   geocoded_by :address
   after_validation :geocode, if: :will_save_change_to_address?
+  before_validation :assign_default_image_url
+
   def formatted_duration
     total_minutes = ((end_date - start_date) / 60).round
 
@@ -15,5 +18,11 @@ class Activity < ApplicationRecord
       hours = hours == hours.to_i ? hours.to_i : hours.round(1)
       "#{hours} #{'hour'.pluralize(hours)}"
     end
+  end
+
+  private
+
+  def assign_default_image_url
+    self.image_url = DEFAULT_IMAGE_URL if image_url.blank?
   end
 end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -8,6 +8,10 @@ class Trip < ApplicationRecord
 
   attr_accessor :start_date, :end_date
 
+  DEFAULT_IMAGE_URL = "activity-placeholder.svg"
+
+  before_validation :assign_default_image_url
+
   def first_day
     trip_days.minimum(:date)
   end
@@ -37,4 +41,9 @@ class Trip < ApplicationRecord
     trip_days.sum { |trip_day| trip_day.activities.size }
   end
 
+  private
+
+  def assign_default_image_url
+    self.image_url = DEFAULT_IMAGE_URL if image_url.blank?
+  end
 end

--- a/app/views/activities/edit.html.erb
+++ b/app/views/activities/edit.html.erb
@@ -1,7 +1,9 @@
 <div class="activity-edit-header">
   <div class="activity-edit-header__thumb">
     <% if @activity.image_url.present? %>
-      <%= image_tag @activity.image_url, alt: @activity.name %>
+      <%= image_tag @activity.image_url,
+                    alt: @activity.name,
+                    onerror: "this.onerror=null;this.src='#{image_path(Activity::DEFAULT_IMAGE_URL)}'" %>
     <% else %>
       <i class="fa-solid fa-mountain-sun"></i>
     <% end %>

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -1,4 +1,7 @@
-<%= image_tag @activity.image_url.presence || "activity-placeholder.svg", alt: @activity.name, class: "activity-show__image" %>
+<%= image_tag @activity.image_url.presence || Activity::DEFAULT_IMAGE_URL,
+              alt: @activity.name,
+              class: "activity-show__image",
+              onerror: "this.onerror=null;this.src='#{image_path(Activity::DEFAULT_IMAGE_URL)}'" %>
 
 <span class="activity-card__chip"><%= @activity.category %></span>
 <h1><%= @activity.name %></h1>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -68,6 +68,13 @@
 
       </div>
 
+    <% elsif message.content == "GENERATING_ITINERARY" %>
+
+      <div class="message-bubble message-bubble-assistant message-content"
+           data-controller="generating-message">
+        <span data-generating-message-target="text"></span>
+      </div>
+
     <% else %>
 
       <div class="message-bubble message-bubble-assistant message-content">

--- a/app/views/trips/index.html.erb
+++ b/app/views/trips/index.html.erb
@@ -20,7 +20,10 @@
     <% if @upcoming_trip %>
       <%= link_to trip_path(@upcoming_trip), class: "trip-hero" do %>
         <div class="trip-hero__image-wrap">
-          <%= image_tag @upcoming_trip.image_url, alt: @upcoming_trip.destination, class: "trip-hero__image" %>
+          <%= image_tag @upcoming_trip.image_url.presence || Trip::DEFAULT_IMAGE_URL,
+                        alt: @upcoming_trip.destination,
+                        class: "trip-hero__image",
+                        onerror: "this.onerror=null;this.src='#{image_path(Trip::DEFAULT_IMAGE_URL)}'" %>
 
           <span class="trip-hero__badge trip-hero__badge--destination">
             <i class="fa-solid fa-location-dot"></i> <%= @upcoming_trip.destination.to_s.upcase %>
@@ -89,7 +92,10 @@
               <div class="trip-cards">
                 <% trips_for_status.each do |trip| %>
                   <%= link_to trip_path(trip), class: "trip-card" do %>
-                    <%= image_tag trip.image_url, alt: trip.destination, class: "trip-card__image" %>
+                    <%= image_tag trip.image_url.presence || Trip::DEFAULT_IMAGE_URL,
+                                  alt: trip.destination,
+                                  class: "trip-card__image",
+                                  onerror: "this.onerror=null;this.src='#{image_path(Trip::DEFAULT_IMAGE_URL)}'" %>
                     <div class="trip-card__body">
                       <h4 class="trip-card__name"><%= trip.destination %></h4>
                       <p class="trip-card__meta">

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -53,7 +53,10 @@
          data-controller="activity-card"
          data-activity-card-url-value="<%= trip_trip_day_activity_path(@trip, @trip_day, a) %>"
          data-action="click->activity-card#visit click@window->activity-card#closeMenu">
-      <img class="activity-card__thumb" src="<%= a.image_url %>" alt="<%= a.name %>" />
+      <%= image_tag a.image_url.presence || Activity::DEFAULT_IMAGE_URL,
+                    class: "activity-card__thumb",
+                    alt: a.name,
+                    onerror: "this.onerror=null;this.src='#{image_path(Activity::DEFAULT_IMAGE_URL)}'" %>
 
       <div class="activity-card__content">
         <div class="activity-card__header">

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,9 +1,7 @@
-# Async adapter only works within the same process, so for manually triggering cable updates from a console,
-# and seeing results in the browser, you must do so from the web console (running inside the dev process),
-# not a terminal started via bin/rails console! Add "console" to any action or any ERB template view
-# to make the web console appear.
 development:
-  adapter: async
+  adapter: solid_cable
+  polling_interval: 0.1.seconds
+  message_retention: 1.day
 
 test:
   adapter: test


### PR DESCRIPTION
Itinerary generation moved to a background job.

Improved loading state and delivery of itinerary.

Fallback for trip and activity default image.

Net effect: generating a trip itinerary no longer ties up a web worker or times out the browser, the UI now reliably tells the user when it's done (with a bit of personality while they wait), and trip/activity images can no longer break the page or show a broken-image icon.