### PR TITLE
Chatbot preselects

### DIFF
--- a/app/assets/stylesheets/pages/_chat.scss
+++ b/app/assets/stylesheets/pages/_chat.scss
@@ -1,11 +1,10 @@
 .chat-page {
-  height: 100vh;
+  height: 100dvh;
   max-width: 480px;
   margin: 0 auto;
   padding: 0 20px;
   background: $color-background;
   color: $color-text;
-
   display: flex;
   flex-direction: column;
 }
@@ -89,12 +88,115 @@
 }
 
 .message-content {
-  white-space: pre-line;
+  white-space: normal;
+}
+
+.chat-options {
+  width: 100%;
+  margin-top: 10px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.chat-options-header {
+  margin-left: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  color: $color-text-secondary;
+}
+
+.chat-option-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chat-option {
+  min-height: 38px;
+  padding: 8px 14px;
+
+  background: $color-surface;
+  border: 1px solid $color-border;
+  border-radius: 10px;
+
+  color: $color-text;
+  font-size: 13px;
+  font-weight: 600;
+
+  cursor: pointer;
+}
+
+.chat-option:hover {
+  border-color: $color-primary;
+}
+
+.chat-option--selected {
+  background: $color-primary;
+  border-color: $color-primary;
+  color: $color-text;
+}
+
+.chat-options-continue {
+  width: 100%;
+  height: 40px;
+
+  border: 0;
+  border-radius: 10px;
+
+  background: $color-primary;
+  color: $color-text;
+
+  font-size: 13px;
+  font-weight: 700;
+
+  cursor: pointer;
+}
+
+.chat-traveler-counter {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.chat-traveler-counter[hidden] {
+  display: none;
+}
+
+.chat-traveler-counter > button:not(.chat-options-continue) {
+  width: 38px;
+  height: 38px;
+  padding: 0;
+
+  border: 1px solid $color-border;
+  border-radius: 10px;
+
+  background: $color-surface;
+  color: $color-text;
+
+  font-size: 18px;
+  font-weight: 700;
+
+  cursor: pointer;
+}
+
+.chat-traveler-counter > span {
+  min-width: 28px;
+  font-size: 15px;
+  font-weight: 700;
+  text-align: center;
+  color: $color-text;
+}
+
+.chat-traveler-counter .chat-options-continue {
+  flex: 1;
+  width: auto;
 }
 
 .chat-composer {
   flex-shrink: 0;
-  padding: 12px 0 20px;
+  padding: 12px 0 90px;
   background: $color-background;
 }
 
@@ -121,6 +223,7 @@
   outline: 0;
   color: $color-text;
   font-size: 14.5px;
+  resize: none;
 }
 
 .message-input::placeholder {
@@ -176,16 +279,13 @@
 
   h3 {
     margin: 0 0 3px;
-
     font-size: 18px;
     font-weight: 800;
-
     color: $color-text;
   }
 
   p {
     margin: 0;
-
     font-size: 13px;
     color: $color-text-secondary;
   }
@@ -203,16 +303,13 @@
   display: flex;
   justify-content: space-between;
   gap: 20px;
-
   padding: 6px 0;
 }
 
 .trip-recap-label {
   flex-shrink: 0;
-
   font-size: 12px;
   font-weight: 700;
-
   color: $color-text-secondary;
 }
 
@@ -220,17 +317,14 @@
   font-size: 13px;
   line-height: 1.4;
   text-align: right;
-
   color: $color-text;
 }
 
 .draft-ready-status {
   margin-bottom: 10px;
-
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.08em;
-
   color: $color-primary-text;
 }
 

--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -5,6 +5,8 @@ class ChatsController < ApplicationController
 
     @chat = @trip.chats.find(params[:id])
     @message = Message.new
+
+    @question_index = @chat.messages.where(role: "user").count
   end
 
   def create

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,31 +2,23 @@ class MessagesController < ApplicationController
   QUESTIONS = [
     {
       key: :group_size,
-      instruction: "Ask how many people are traveling. Give simple examples like 1, 2, 3, or 4+."
-    },
-    {
-      key: :vibe,
-      instruction: "Ask what vibe they want. Give options like relaxed, adventurous, lively, or a mix."
+      instruction: "Ask how many people are traveling."
     },
     {
       key: :budget,
-      instruction: "Ask for their approximate budget per day. They can give an amount or say budget, moderate, or luxury."
+      instruction: "Ask for their approximate daily budget."
     },
     {
-      key: :pace,
-      instruction: "Ask what pace they prefer. Give options like chill, balanced, or packed."
+      key: :travel_style,
+      instruction: "Ask about their travel style. They can choose more than one, such as relaxed, social, adventurous, spontaneous, or packed."
     },
     {
-      key: :interests,
-      instruction: "Ask about their main interests. Give options like nature, food, culture, nightlife, adventure, or a mix."
-    },
-    {
-      key: :must_see,
-      instruction: "Ask if there is anything they definitely want to see or do. Make it clear that 'nothing specific' is completely fine."
+      key: :focus,
+      instruction: "Ask what they want to focus on during the trip. They can choose more than one, such as culture, food, nature, nightlife, adventure, or shopping."
     },
     {
       key: :transportation,
-      instruction: "Ask how they prefer to get around. Give options like walking, public transport, car rental, rideshare, or a mix."
+      instruction: "Ask how they prefer to get around. They can choose more than one, such as walking, public transport, or car."
     }
   ].freeze
 
@@ -96,6 +88,25 @@ class MessagesController < ApplicationController
     params.require(:message).permit(:content)
   end
 
+  def questionnaire_answers
+    @chat.messages
+        .where(role: "user")
+        .order(:created_at)
+        .limit(QUESTIONS.length)
+  end
+
+  def save_trip_preferences
+    answer_number = questionnaire_answers.count
+
+    case answer_number
+    when 1
+      group_size = @message.content.to_s[/\d+/]&.to_i
+      @trip.update!(group_size: group_size) if group_size.present? && group_size.positive?
+    when 3
+      @trip.update!(vibe: @message.content.strip)
+    end
+  end
+
   def continue_conversation
     if full_itinerary_request?
       generate_itinerary
@@ -106,6 +117,8 @@ class MessagesController < ApplicationController
       handle_modification_request
       return
     end
+
+    save_trip_preferences
 
     if questionnaire_complete?
       generate_summary
@@ -136,13 +149,6 @@ class MessagesController < ApplicationController
                .ask(@message.content)
 
     set_assistant_message(response.content)
-  end
-
-  def questionnaire_answers
-    @chat.messages
-         .where(role: "user")
-         .order(:created_at)
-         .limit(QUESTIONS.length)
   end
 
   def questionnaire_context

--- a/app/javascript/controllers/chat_options_controller.js
+++ b/app/javascript/controllers/chat_options_controller.js
@@ -1,0 +1,97 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [
+    "travelerCounter",
+    "travelerCount"
+  ]
+
+  connect() {
+    this.selectedValues = []
+    this.travelerCount = 4
+  }
+
+  selectTraveler(event) {
+    const button = event.currentTarget
+    const value = Number(button.dataset.value)
+
+    this.clearSelectedOptions()
+    button.classList.add("chat-option--selected")
+
+    if (value === 4) {
+      this.travelerCount = 4
+      this.travelerCountTarget.textContent = this.travelerCount
+      this.travelerCounterTarget.hidden = false
+      return
+    }
+
+    this.submitValue(value.toString())
+  }
+
+  increaseTraveler() {
+    this.travelerCount += 1
+    this.travelerCountTarget.textContent = this.travelerCount
+  }
+
+  decreaseTraveler() {
+    if (this.travelerCount <= 4) return
+
+    this.travelerCount -= 1
+    this.travelerCountTarget.textContent = this.travelerCount
+  }
+
+  submitTraveler() {
+    this.submitValue(this.travelerCount.toString())
+  }
+
+  selectSingle(event) {
+    const button = event.currentTarget
+
+    this.clearSelectedOptions()
+    button.classList.add("chat-option--selected")
+
+    this.submitValue(button.dataset.value)
+  }
+
+  toggleMulti(event) {
+    const button = event.currentTarget
+    const value = button.dataset.value
+
+    button.classList.toggle("chat-option--selected")
+
+    if (button.classList.contains("chat-option--selected")) {
+      if (!this.selectedValues.includes(value)) {
+        this.selectedValues.push(value)
+      }
+    } else {
+      this.selectedValues = this.selectedValues.filter(
+        selectedValue => selectedValue !== value
+      )
+    }
+  }
+
+  submitMulti() {
+    if (this.selectedValues.length === 0) return
+
+    this.submitValue(this.selectedValues.join(", "))
+  }
+
+  submitValue(value) {
+    const form = document.querySelector(".message-form")
+
+    if (!form) return
+
+    const input = form.querySelector(".message-input")
+
+    if (!input) return
+
+    input.value = value
+    form.requestSubmit()
+  }
+
+  clearSelectedOptions() {
+    this.element.querySelectorAll(".chat-option").forEach((button) => {
+      button.classList.remove("chat-option--selected")
+    })
+  }
+}

--- a/app/prompts/messages/summary.txt
+++ b/app/prompts/messages/summary.txt
@@ -4,6 +4,13 @@ Create a short recap of the user's trip preferences.
 
 Use the original trip information and questionnaire answers.
 
+The questionnaire answers are provided in this exact order:
+1. Travelers
+2. Budget
+3. Travel style
+4. Trip focus
+5. Transportation
+
 Do not create the itinerary yet.
 Do not invent information.
 Keep each value short.
@@ -11,11 +18,9 @@ Keep each value short.
 Use exactly this format:
 
 Travelers: value
-Vibe: value
 Budget: value
-Pace: value
-Interests: value
-Must-see: value
+Travel style: value
+Trip focus: value
 Transportation: value
 
 Do not use Markdown.

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -16,12 +16,10 @@
                 },
                 placeholder: "Tell itinera..." %>
 
-    <%= f.button :button,
-                 type: "submit",
-                 class: "message-send-button",
-                 aria: { label: "Send message" } do %>
+    <button type="submit"
+            class="message-send-button"
+            aria-label="Send message">
       <i class="fa-solid fa-arrow-up"></i>
-    <% end %>
+    </button>
   </div>
-
 <% end %>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -78,6 +78,178 @@
         <% end %>
       </div>
 
+      <% question_index = message.chat.messages
+                                  .where(role: "user")
+                                  .where("created_at < ?", message.created_at)
+                                  .count %>
+
+      <% if message.content.present? && question_index < 5 %>
+        <div class="chat-options" data-controller="chat-options">
+          <% if question_index == 0 %>
+
+            <div class="chat-options-header">
+              choose one
+            </div>
+
+            <div class="chat-option-list">
+              <% [1, 2, 3].each do |number| %>
+                <button
+                  type="button"
+                  class="chat-option"
+                  data-action="chat-options#selectTraveler"
+                  data-value="<%= number %>"
+                >
+                  <%= number %>
+                </button>
+              <% end %>
+
+              <button
+                type="button"
+                class="chat-option"
+                data-action="chat-options#selectTraveler"
+                data-value="4"
+              >
+                4+
+              </button>
+            </div>
+
+            <div
+              class="chat-traveler-counter"
+              data-chat-options-target="travelerCounter"
+              hidden
+            >
+              <button
+                type="button"
+                data-action="chat-options#decreaseTraveler"
+              >
+                −
+              </button>
+
+              <span data-chat-options-target="travelerCount">
+                4
+              </span>
+
+              <button
+                type="button"
+                data-action="chat-options#increaseTraveler"
+              >
+                +
+              </button>
+
+              <button
+                type="button"
+                class="chat-options-continue"
+                data-action="chat-options#submitTraveler"
+              >
+                continue
+              </button>
+            </div>
+
+          <% elsif question_index == 1 %>
+
+            <div class="chat-options-header">
+              choose one
+            </div>
+
+            <div class="chat-option-list">
+              <% ["under $50", "$50–$150", "$150–$300", "$300+"].each do |option| %>
+                <button
+                  type="button"
+                  class="chat-option"
+                  data-action="chat-options#selectSingle"
+                  data-value="<%= option %>"
+                >
+                  <%= option %>
+                </button>
+              <% end %>
+            </div>
+
+          <% elsif question_index == 2 %>
+
+            <div class="chat-options-header">
+              select all that apply
+            </div>
+
+            <div class="chat-option-list">
+              <% ["relaxed", "social", "adventurous", "spontaneous", "packed"].each do |option| %>
+                <button
+                  type="button"
+                  class="chat-option"
+                  data-action="chat-options#toggleMulti"
+                  data-value="<%= option %>"
+                >
+                  <%= option.humanize %>
+                </button>
+              <% end %>
+            </div>
+
+            <button
+              type="button"
+              class="chat-options-continue"
+              data-action="chat-options#submitMulti"
+            >
+              continue
+            </button>
+
+          <% elsif question_index == 3 %>
+
+            <div class="chat-options-header">
+              select all that apply
+            </div>
+
+            <div class="chat-option-list">
+              <% ["nightlife", "shopping", "culture", "food", "nature", "adventure"].each do |option| %>
+                <button
+                  type="button"
+                  class="chat-option"
+                  data-action="chat-options#toggleMulti"
+                  data-value="<%= option %>"
+                >
+                  <%= option.humanize %>
+                </button>
+              <% end %>
+            </div>
+
+            <button
+              type="button"
+              class="chat-options-continue"
+              data-action="chat-options#submitMulti"
+            >
+              continue
+            </button>
+
+          <% elsif question_index == 4 %>
+
+            <div class="chat-options-header">
+              select all that apply
+            </div>
+
+            <div class="chat-option-list">
+              <% ["walking", "public transport", "car"].each do |option| %>
+                <button
+                  type="button"
+                  class="chat-option"
+                  data-action="chat-options#toggleMulti"
+                  data-value="<%= option %>"
+                >
+                  <%= option.humanize %>
+                </button>
+              <% end %>
+            </div>
+
+            <button
+              type="button"
+              class="chat-options-continue"
+              data-action="chat-options#submitMulti"
+            >
+              continue
+            </button>
+
+          <% end %>
+
+        </div>
+      <% end %>
+
     <% end %>
 
   </div>


### PR DESCRIPTION
Adds selectable preset options to the trip planning chat to make the questionnaire faster and easier to complete.

- Adds single-select options for travelers and budget
- Adds multi-select options for travel style, trip focus, and transportation
- Adds 4+ traveler counter
- Saves travelers to group_size and travel style to vibe
- Keeps manual chat input available
- Hides preset options while the assistant question is still loading